### PR TITLE
fix for windows

### DIFF
--- a/packages/less_compiler/controller.php
+++ b/packages/less_compiler/controller.php
@@ -21,7 +21,7 @@ class LessCompilerPackage extends Package {
 			$path = $theme->getThemeDirectory();
 			define(LESSDIR,realpath($path).'/less');
 		}
-		if (!defined(CSSDIR))  define(CSSDIR,  DIR_FILES_UPLOADED.'/CSS/');
+		if (!defined(CSSDIR))  define(CSSDIR,  DIR_FILES_UPLOADED.'/css/');
 	}
 
 	public function install() {

--- a/packages/less_compiler/helpers/less.php
+++ b/packages/less_compiler/helpers/less.php
@@ -46,9 +46,10 @@ class lessHelper {
 		}
 		$dir = substr($dir,strlen(realpath(DIR_BASE)));
 		if (substr($file,-5) == '.less') {
-			return BASE_URL.DIR_REL.$dir.'/'.substr($file, 0, strlen($file) - 5).'.css';
+                    $cssFile = BASE_URL.DIR_REL.$dir.'/'.substr($file, 0, strlen($file) - 5).'.css';
 		} else {
-			return BASE_URL.DIR_REL.$dir.'/'.$file;
+                    $cssFile = BASE_URL.DIR_REL.$dir.'/'.$file;
 		}
+                return str_replace(DIRECTORY_SEPARATOR,'/',$cssFile);
 	}
 }


### PR DESCRIPTION
I've made the "css" directory lower case, I don't think I've ever seen an uppercase concrete5 directory

I've also replaced slashes because the path on Windows is by default \files\css...
